### PR TITLE
Bump bundler from 2.3.26 to 2.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 - Update gem dependencies.
+- Bump bundler from 2.3.26 to 2.6.3.
 
 ## v11.2.0 (2025-02-04)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,4 +74,4 @@ DEPENDENCIES
   yard (= 0.9.26)
 
 BUNDLED WITH
-   2.3.26
+   2.6.3


### PR DESCRIPTION
Motivation: I think that the newer version of bundler prints warnings like `warning: irb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0`, whereas I think that the older version does not, and I want to see this warnings, so that I can be sure to require the necessary gems.