### PR TITLE
Add irb and reline dependencies to gemspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 - Update gem dependencies.
 - Bump bundler from 2.3.26 to 2.6.3.
+- Add `irb` and `reline` dependencies to gemspec.
 
 ## v11.2.0 (2025-02-04)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,8 @@ PATH
   remote: .
   specs:
     runger_byebug (11.2.1.alpha)
+      irb
+      reline
 
 GEM
   remote: https://rubygems.org/
@@ -25,21 +27,37 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
+    date (3.4.1)
     docile (1.4.1)
     drb (2.2.1)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
+    io-console (0.8.0)
+    irb (1.15.1)
+      pp (>= 0.6.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
     logger (1.6.5)
     memo_wise (1.10.0)
     method_source (1.1.0)
     minitest (5.25.4)
+    pp (0.6.2)
+      prettyprint
+    prettyprint (0.2.0)
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    psych (5.2.3)
+      date
+      stringio
     rainbow (3.1.1)
     rake (13.2.1)
     rake-compiler (1.2.9)
       rake
+    rdoc (6.11.0)
+      psych (>= 4.0.0)
+    reline (0.6.0)
+      io-console (~> 0.5)
     runger_release_assistant (2.0.0)
       activesupport (>= 6)
       memo_wise (>= 1.7)
@@ -53,6 +71,7 @@ GEM
     simplecov-html (0.13.1)
     simplecov_json_formatter (0.1.4)
     slop (4.10.1)
+    stringio (3.1.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     uri (1.0.2)

--- a/byebug.gemspec
+++ b/byebug.gemspec
@@ -26,4 +26,7 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
 
   s.add_development_dependency "bundler", "~> 2.0"
+
+  s.add_dependency "irb"
+  s.add_dependency "reline"
 end


### PR DESCRIPTION
Prior to this change, we see this warnings:

```
~/code/runger_byebug  add-gems-removed-from-stdlib-to-gemspec ✔   06:52:47 AM
❯ bin/rake
[...]
/home/david/.rbenv/versions/3.4.1/lib/ruby/3.4.0/readline.rb:4: warning: reline was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add reline to your Gemfile or gemspec to silence this warning.
/home/david/code/runger_byebug/lib/byebug/commands/irb.rb:4: warning: irb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add irb to your Gemfile or gemspec to silence this warning.
[...]
```

This change removes those warnings.