### PR TITLE
Add metadata to gemspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- Add metadata to gemspec.
 
 ## v11.3.0 (2025-02-05)
 - Update gem dependencies.

--- a/byebug.gemspec
+++ b/byebug.gemspec
@@ -8,13 +8,23 @@ Gem::Specification.new do |s|
   s.authors = ["David Runger"] # forked from ["David Rodriguez", "Kent Sibilev", "Mark Moseley"]
   s.email = "davidjrunger@gmail.com"
   s.license = "BSD-2-Clause"
-  s.homepage = "https://github.com/davidrunger/byebug"
+  s.homepage = "https://github.com/davidrunger/runger_byebug"
   s.summary = "Ruby fast debugger - base + CLI"
   s.description = "Byebug is a Ruby debugger. It's implemented using the
     TracePoint C API for execution control and the Debug Inspector C API for
     call stack navigation.  The core component provides support that front-ends
     can build on. It provides breakpoint handling and bindings for stack frames
     among other things and it comes with an easy to use command line interface."
+
+  if s.respond_to?(:metadata)
+    s.metadata["rubygems_mfa_required"] = "true"
+
+    s.metadata["homepage_uri"] = s.homepage
+    s.metadata["source_code_uri"] = "https://github.com/davidrunger/runger_byebug"
+    s.metadata["changelog_uri"] = "https://github.com/davidrunger/runger_byebug/blob/main/CHANGELOG.md"
+  else
+    raise("RubyGems 2.0 or newer is required to protect against public gem pushes.")
+  end
 
   s.required_ruby_version = ">= 2.5.0"
 


### PR DESCRIPTION
I am hoping that this will allow Dependabot to add info about the changes in the updated versions of this gem to PRs that it creates to update this gem in other projects. Dependabot currently seems not to be doing that (e.g. here: https://github.com/davidrunger/david_runger/pull/6017).