### PR TITLE
Remove all version constraints from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,11 @@ source "https://rubygems.org"
 gemspec
 
 group :development do
-  gem "minitest", "~> 5.11"
-  gem "pry", "0.14.1"
-  gem "rake", "~> 13.0"
-  gem "rake-compiler", "~> 1.0"
+  gem "minitest"
+  gem "pry"
+  gem "rake"
+  gem "rake-compiler"
   gem "runger_release_assistant", require: false
-  gem "simplecov", "0.21.2"
-  gem "yard", "0.9.26"
+  gem "simplecov"
+  gem "yard"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,14 +83,14 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 2.0)
-  minitest (~> 5.11)
-  pry (= 0.14.1)
-  rake (~> 13.0)
-  rake-compiler (~> 1.0)
+  minitest
+  pry
+  rake
+  rake-compiler
   runger_byebug!
   runger_release_assistant
-  simplecov (= 0.21.2)
-  yard (= 0.9.26)
+  simplecov
+  yard
 
 BUNDLED WITH
    2.6.3


### PR DESCRIPTION
Motivation: I try to stay updated with the latest available gem versions. This will make that easier, since e.g. `bundle update` will now try to update to the latest versions, which I think it wouldn't before.