### PR TITLE
[gemspec] Remove 'bundler' as an explicit development dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- Remove `bundler` as an explicit development dependency.
 
 ## v11.4.0 (2025-02-05)
 - Add metadata to gemspec.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  bundler (~> 2.0)
   minitest
   pry
   rake

--- a/byebug.gemspec
+++ b/byebug.gemspec
@@ -35,8 +35,6 @@ Gem::Specification.new do |s|
   s.extensions = ["ext/byebug/extconf.rb"]
   s.require_path = "lib"
 
-  s.add_development_dependency "bundler", "~> 2.0"
-
   s.add_dependency "irb"
   s.add_dependency "reline"
 end


### PR DESCRIPTION
Since Ruby 2.6, `bundler` is included with Ruby by default, so I don't think we really need to specify it explicitly as a dependency.

> Since Ruby 2.6, Bundler is a part of Ruby's standard library.

-- https://ruby-doc.org/stdlib-2.7.1/libdoc/bundler/rdoc/Bundler.html